### PR TITLE
chore: Deduplicate identical function overloads

### DIFF
--- a/R/duckdb-funs.R
+++ b/R/duckdb-funs.R
@@ -2623,12 +2623,7 @@ current_connection_id <- function() {
 #' Returns the name of the currently active database.
 #'
 #' @name current_database
-#' @usage NULL
-#' @section Overloads:
-#' \itemize{
-#' \item \code{current_database()}
-#' \item \code{current_database()}
-#' }
+#' @usage current_database()
 
 #' @return `VARCHAR`
 #' @export
@@ -2646,12 +2641,7 @@ current_database <- function() {
 #' Returns the current query as a string.
 #'
 #' @name current_query
-#' @usage NULL
-#' @section Overloads:
-#' \itemize{
-#' \item \code{current_query()}
-#' \item \code{current_query()}
-#' }
+#' @usage current_query()
 
 #' @return `VARCHAR`
 #' @export
@@ -2701,12 +2691,7 @@ current_role <- function() {
 #' Returns the name of the currently active schema. Default is main.
 #'
 #' @name current_schema
-#' @usage NULL
-#' @section Overloads:
-#' \itemize{
-#' \item \code{current_schema()}
-#' \item \code{current_schema()}
-#' }
+#' @usage current_schema()
 
 #' @return `VARCHAR`
 #' @export
@@ -3414,12 +3399,7 @@ disable_profile <- function() {
 #' DuckDB function `disable_profiling()`.
 #'
 #' @name disable_profiling
-#' @usage NULL
-#' @section Overloads:
-#' \itemize{
-#' \item \code{disable_profiling()}
-#' \item \code{disable_profiling()}
-#' }
+#' @usage disable_profiling()
 
 #' @return Unspecified.
 #' @export
@@ -4647,7 +4627,6 @@ fmod <- function(x, y) {
 #' \itemize{
 #' \item \code{force_checkpoint()}
 #' \item \code{force_checkpoint(col0 = VARCHAR)}
-#' \item \code{force_checkpoint()}
 #' }
 #' @param col0 `VARCHAR`
 #' @return Unspecified.
@@ -13370,12 +13349,7 @@ verify_serializer <- function() {
 #' Returns the currently active version of DuckDB in this format: v0.3.2	.
 #'
 #' @name version
-#' @usage NULL
-#' @section Overloads:
-#' \itemize{
-#' \item \code{version()}
-#' \item \code{version()}
-#' }
+#' @usage version()
 
 #' @return `VARCHAR`
 #' @export

--- a/man/current_database.Rd
+++ b/man/current_database.Rd
@@ -3,20 +3,15 @@
 \name{current_database}
 \alias{current_database}
 \title{DuckDB function current_database}
+\usage{
+current_database()
+}
 \value{
 \code{VARCHAR}
 }
 \description{
 Returns the name of the currently active database.
 }
-\section{Overloads}{
-
-\itemize{
-\item \code{current_database()}
-\item \code{current_database()}
-}
-}
-
 \section{SQL examples}{
 
 

--- a/man/current_query.Rd
+++ b/man/current_query.Rd
@@ -3,20 +3,15 @@
 \name{current_query}
 \alias{current_query}
 \title{DuckDB function current_query}
+\usage{
+current_query()
+}
 \value{
 \code{VARCHAR}
 }
 \description{
 Returns the current query as a string.
 }
-\section{Overloads}{
-
-\itemize{
-\item \code{current_query()}
-\item \code{current_query()}
-}
-}
-
 \section{SQL examples}{
 
 

--- a/man/current_schema.Rd
+++ b/man/current_schema.Rd
@@ -3,20 +3,15 @@
 \name{current_schema}
 \alias{current_schema}
 \title{DuckDB function current_schema}
+\usage{
+current_schema()
+}
 \value{
 \code{VARCHAR}
 }
 \description{
 Returns the name of the currently active schema. Default is main.
 }
-\section{Overloads}{
-
-\itemize{
-\item \code{current_schema()}
-\item \code{current_schema()}
-}
-}
-
 \section{SQL examples}{
 
 

--- a/man/disable_profiling.Rd
+++ b/man/disable_profiling.Rd
@@ -3,17 +3,12 @@
 \name{disable_profiling}
 \alias{disable_profiling}
 \title{DuckDB function disable_profiling}
+\usage{
+disable_profiling()
+}
 \value{
 Unspecified.
 }
 \description{
 DuckDB function \code{disable_profiling()}.
 }
-\section{Overloads}{
-
-\itemize{
-\item \code{disable_profiling()}
-\item \code{disable_profiling()}
-}
-}
-

--- a/man/force_checkpoint.Rd
+++ b/man/force_checkpoint.Rd
@@ -17,7 +17,6 @@ DuckDB function \code{force_checkpoint()}.
 \itemize{
 \item \code{force_checkpoint()}
 \item \code{force_checkpoint(col0 = VARCHAR)}
-\item \code{force_checkpoint()}
 }
 }
 

--- a/man/version.Rd
+++ b/man/version.Rd
@@ -3,20 +3,15 @@
 \name{version}
 \alias{version}
 \title{DuckDB function version}
+\usage{
+version()
+}
 \value{
 \code{VARCHAR}
 }
 \description{
 Returns the currently active version of DuckDB in this format: v0.3.2	.
 }
-\section{Overloads}{
-
-\itemize{
-\item \code{version()}
-\item \code{version()}
-}
-}
-
 \section{SQL examples}{
 
 

--- a/scripts/generate.R
+++ b/scripts/generate.R
@@ -67,30 +67,37 @@ usage_and_params <- function(
   macro_definition,
   examples
 ) {
-  if (length(parameters) == 1) {
+  signatures <- map2_chr(
+    parameters,
+    parameter_types,
+    ~ {
+      if (length(.x) == 0) {
+        sig <- "" # No parameters
+      } else {
+        sig <- paste0(
+          tibble:::tick_if_needed(.x),
+          param_type_tick_if_needed(.y),
+          collapse = ", "
+        )
+      }
+      glue("{tibble:::tick_if_needed(function_name)}({sig})")
+    }
+  )
+  # DuckDB registers some functions under several `function_type`s (e.g. both a
+  # table function and a pragma) with identical parameters, yielding duplicate
+  # overloads. Keep each distinct signature once.
+  dedup <- !duplicated(signatures)
+
+  if (sum(dedup) == 1) {
+    idx <- which(dedup)
     usage_doc <- glue(
-      "#' @usage {usage_signature(function_name, parameters[[1]], parameter_types[[1]])}"
+      "#' @usage {usage_signature(function_name, parameters[[idx]], parameter_types[[idx]])}"
     )
   } else if (function_name == "%") {
     # FIXME: roxygen2 generates bad .Rd here
     usage_doc <- "#' @usage NULL\n"
   } else {
-    signatures <- map2_chr(
-      parameters,
-      parameter_types,
-      ~ {
-        if (length(.x) == 0) {
-          sig <- "" # No parameters
-        } else {
-          sig <- paste0(
-            tibble:::tick_if_needed(.x),
-            param_type_tick_if_needed(.y),
-            collapse = ", "
-          )
-        }
-        glue("{tibble:::tick_if_needed(function_name)}({sig})")
-      }
-    )
+    signatures <- signatures[dedup]
     usage_doc <- paste0(
       "#' @usage NULL\n",
       "#' @section Overloads:\n",


### PR DESCRIPTION
## Summary

While reviewing the `.Rd` changes from #21, I found six functions whose generated docs listed the **same signature twice** under "Overloads". DuckDB registers them under more than one `function_type` (e.g. both a `table` function and a `pragma`) with identical parameters, and `duckdb_functions()` returns one row per registration:

```r
# disable_profiling
row 1: type=table   params=[]
row 2: type=pragma  params=[]
```

The generator emitted one overload per row, producing e.g.:

```
\section{Overloads}{
\itemize{
\item \code{version()}
\item \code{version()}   % duplicate
}}
```

Affected: `version`, `disable_profiling`, `current_database`, `current_query`, `current_schema`, `force_checkpoint`.

## Fix

`usage_and_params()` now collapses identical signatures before rendering:

- When only **one** distinct signature remains, it emits a normal single `\usage{}` block (so `version()`, `disable_profiling()` etc. get a clean page again).
- Functions with genuinely distinct overloads are unaffected — e.g. `force_checkpoint` had three rows (`()`, `(col0 = VARCHAR)`, `()`) and now correctly shows the two distinct ones.

## Scope

Regeneration touches only `scripts/generate.R`, `R/duckdb-funs.R`, and the six `man/*.Rd` pages above. The package documents and loads cleanly.

### Note on the rest of the #21 review

The other substantial `.Rd` changes in #21 are faithful to upstream DuckDB 1.5.4 and need no code change:

- **`&&` (and-and)** now shows a GEOMETRY bounding-box description/example even for the list overload. This is a DuckDB metadata quirk — `duckdb_functions()` reports a single description/example per function *name* across overloads, and the spatial `&&` overload's text now represents the name. Not fixable without overriding upstream data.
- **`read_blob`/`read_text`** dropped their named optional parameters, and **`read_csv`/`parquet_scan`** reordered/added parameters (`thousands`, `strict_mode`, `decimal_separator`, …) — all upstream catalog changes.
- **`array_intersect`/`list_intersect`/`decode`/`regexp_extract_all`/`strftime`/`first`/`last`** gained real typed signatures, descriptions, examples, or new overloads — upstream improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhTCxvawHpRbPzeb4m4LFE)_