### PR TITLE
fix(ci): skip rcc-dev matrix job when there are no dev dependencies

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -125,7 +125,12 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          remotes::install_runiverse("${{ matrix.package }}", linux_distro = "noble")
+          package <- "${{ matrix.package }}"
+          # Guard against an empty matrix entry: with no dev dependencies
+          # there is nothing to install, and install_runiverse("") errors.
+          if (nzchar(package)) {
+            remotes::install_runiverse(package, linux_distro = "noble")
+          }
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/dep-matrix/action.yml
+++ b/.github/workflows/dep-matrix/action.yml
@@ -124,11 +124,21 @@ runs:
           writeLines(paste0("::warning::", msg))
         }
 
-        json <- paste0(
-          '{"package":[',
-          paste0('"', deps, '"', collapse = ","),
-          ']}'
-        )
+        # Build the matrix JSON explicitly for the empty case.
+        # paste0('"', character(0), '"') collapses to the two-character
+        # string '""', which would emit {"package":[""]} (a single empty
+        # package) instead of an empty array, causing a spurious job that
+        # runs install_runiverse("") and fails. Emit an empty array so the
+        # dependent matrix job is skipped when there are no dev deps.
+        if (length(deps) == 0) {
+          json <- '{"package":[]}'
+        } else {
+          json <- paste0(
+            '{"package":[',
+            paste0('"', deps, '"', collapse = ","),
+            ']}'
+          )
+        }
         writeLines(json)
         writeLines(paste0("matrix=", json), Sys.getenv("GITHUB_OUTPUT"))
       shell: Rscript {0}


### PR DESCRIPTION
## Problem

The `rcc dev` workflow (`.github/workflows/R-CMD-check-dev.yaml`) has been failing on every scheduled run. The failing step is not R CMD check — the `base` job's check passes — but the earlier **"Install dev version of"** step:

```
remotes::install_runiverse("", linux_distro = "noble")
##[error]Error: JSON: EXPECTED value GOT E
```

## Root cause

`dd` has no package dependencies (only `Depends: R (>= 4.4)`), so `dep-matrix` computes an empty `deps` vector. The matrix JSON was built with:

```r
json <- paste0('{"package":[', paste0('"', deps, '"', collapse = ","), ']}')
```

For `deps = character(0)`, `paste0('"', character(0), '"')` collapses to the two-character string `""`, so the output becomes `{"package":[""]}` — a matrix with **one empty-string package** — instead of an empty array. That spawns a spurious `rcc-dev:` job that runs `remotes::install_runiverse("")`, which errors.

This is a latent bug in the shared cynkra template; it only surfaces for a dependency-free package like `dd`. Repos with real dependencies (e.g. DBItest) never hit it.

## Fix

- **`dep-matrix/action.yml`**: emit `{"package":[]}` when there are no dev dependencies, so the dependent matrix job is skipped (an empty dynamic matrix produces zero jobs).
- **`R-CMD-check-dev.yaml`**: guard the install step with `nzchar()` as defense in depth against an empty matrix entry.

## Verification

- YAML validated and the embedded R in both steps parses.
- JSON construction verified locally: empty deps → `{"package":[]}`; non-empty → `{"package":["DBI"]}` etc.
- No package content changed; the `base` R CMD check job already passes on R 4.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7

---
_Generated by [Claude Code](https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7)_