### PR TITLE
docs: Document the `<->` operator as an alias, without an R object

### DIFF
--- a/R/duckdb-funs.R
+++ b/R/duckdb-funs.R
@@ -5806,6 +5806,10 @@ list_distance <- function(list1 = `FLOAT[] | DOUBLE[]`, list2 = `FLOAT[] | DOUBL
   stop("DuckDB function list_distance() is not available in R.")
 }
 
+#' @rdname list_distance
+#' @name <->
+NULL
+
 #' DuckDB function list_distinct
 #'
 #' @description

--- a/man/list_distance.Rd
+++ b/man/list_distance.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/duckdb-funs.R
 \name{list_distance}
 \alias{list_distance}
+\alias{<->}
 \title{DuckDB function list_distance}
 \usage{
 list_distance(list1, list2)

--- a/scripts/generate.R
+++ b/scripts/generate.R
@@ -745,15 +745,8 @@ funs <-
       examples
     )
   ) |>
-  # Omit `<->` (an alias of the documented `list_distance`). R CMD check's
-  # replacement-function check (`tools:::checkReplaceFuns`) treats every
-  # namespace object whose name *contains* the substring `<-` as a replacement
-  # function and demands its last formal be named `value` -- exported or not.
-  # `<->` takes `(list1, list2)`, so it always trips that check, and there is no
-  # non-misleading signature that would satisfy it. Its canonical page
-  # (`list_distance`) already documents the operation, so nothing user-facing is
-  # lost by dropping the `<->` stub.
-  filter_print(!(function_name %in% c("<->"))) |>
+  # NOTE: `<->` is kept here but emitted as documentation only; see `alias_only`
+  # below.
   # Drop DuckDB's internal decompression helpers: they are implementation
   # details, not user-facing functions.
   filter_print(!stringr::str_detect(function_name, "^__internal")) |>
@@ -810,6 +803,26 @@ funs <-
 # other base-shadowing stubs (`abs()`, `sqrt()`, ...) stay exported as before.
 no_export <- c("format", "+", "-", "length")
 
+# DuckDB names that get a help page but no R function behind it. R CMD check's
+# replacement-function check (`tools:::checkReplaceFuns`) treats every *namespace
+# object* whose name contains the substring `<-` as a replacement function and
+# demands its last formal be named `value`. It inspects the whole namespace, so
+# unlike `no_export` above, withholding the export does not help, and `<->`
+# (list distance) takes `(list1, list2)` -- no honest signature satisfies it.
+#
+# An Rd `\alias{}`, though, is documentation, not an object. Documenting the name
+# on its alias group's page makes `?`<->`` resolve to the same topic as
+# `list_distance()` while nothing of that name ever enters the namespace for the
+# check to find. Such names are correspondingly absent from `NAMESPACE` and from
+# the `dd` list, both of which can only hold real objects.
+no_implement <- c("<->")
+
+# Such a name can only ride along on a page some *other* member of its alias
+# group owns, because it emits no primary block of its own. `pick_rep()` prefers
+# alphanumeric names, so this holds today; assert it so a future addition fails
+# loudly here instead of silently producing an `@rdname` to a missing topic.
+stopifnot(!any(funs$rep_name %in% no_implement))
+
 code <-
   funs |>
   mutate(
@@ -846,7 +859,23 @@ code <-
 
     )"
     ),
-    roxy = if_else(is_primary, primary_roxy, alias_roxy)
+    # Unimplemented names document the name and nothing else: a `NULL` block
+    # named after the function and routed to the group's page, so roxygen2
+    # records an `\alias{{}}` there without an object being defined. (roxygen2
+    # requires `@name` on a `NULL` block; `@rdname` keeps it on the same page.)
+    no_impl_roxy = glue(
+      r"(
+    #' @rdname {rd_name}
+    #' @name {function_name}
+    NULL
+
+    )"
+    ),
+    roxy = case_when(
+      function_name %in% no_implement ~ no_impl_roxy,
+      is_primary ~ primary_roxy,
+      .default = alias_roxy
+    )
   ) |>
   pull(roxy)
 
@@ -874,7 +903,12 @@ code <- c(
 
 writeLines(code, "R/duckdb-funs.R")
 
-dd_names <- sort(funs$function_name[parsed], method = "radix")
+# The `dd` list can only hold real objects, so the documentation-only names are
+# excluded.
+dd_names <- sort(
+  setdiff(funs$function_name[parsed], no_implement),
+  method = "radix"
+)
 
 dd_code <- glue(
   r"(


### PR DESCRIPTION
Recovers `<->`, the one function #32 gave up on. One commit, 3 files.

## The idea

#32 omitted `<->` because R CMD check's `tools:::checkReplaceFuns` rejects it: the
check scans namespace objects whose name *contains* `<-` and demands a last
formal named `value`. It ignores exports, so withholding the export does not
help, and `<->` (list distance) takes `(list1, list2)` — no honest stub passes.

That reasoning is sound, but it is about **objects**.
An Rd `\alias{}` is documentation, not an object — so the *help topic* can exist
even though the *function* cannot.

## What this does

Adds a `no_implement` set: names that are documented but get no R function.
Such a name is emitted as a `NULL` block named after the function and routed to
its alias group's page:

```r
#' @rdname list_distance
#' @name <->
NULL
```

roxygen2 records the `\alias{}` on that page and defines nothing, so the result
is:

```rd
\name{list_distance}
\alias{list_distance}
\alias{<->}
```

…with no `<->` anywhere in `R/` or `NAMESPACE`, and none in the `dd` list, which
can only hold real objects.

This sits alongside the existing primary/alias block templates as a third peer,
rather than reshaping the data around it — each row still renders itself, with no
join and no mid-script mutation of `funs`.

A `stopifnot()` guards the one structural requirement: an unimplemented name
cannot be its group's representative, since it emits no primary block for
`@rdname` to target. `pick_rep()` prefers alphanumeric names so this holds today;
the assertion makes a future addition fail loudly rather than silently emit an
`@rdname` to a missing topic.

This also replaces the now-obsolete comment from #32 explaining why `<->` had to
stay omitted.

## Verified

```r
utils::help("<->", package = "dd")
#> .../dd/help/list_distance

exists("<->", envir = asNamespace("dd"), inherits = FALSE)
#> FALSE
"<->" %in% getNamespaceExports("dd")
#> FALSE
```

R CMD check (`--no-manual --as-cran`): **0 errors, 0 warnings**, only the
pre-existing CRAN incoming-feasibility `NOTE` — in particular no
`checking replacement functions ... WARNING`.

Re-running `scripts/generate.R` on this tip produces no diff, so the committed
output matches the generator exactly.

## Trade-off

With no object behind it, `<->` cannot appear in the `dd` list. What it gains is
the help-system entry — which is the package's stated purpose (*"Lists DuckDB
functions for integration in R's help system"*).

If having ``dd$`<->` `` matters more, the alternative is to map the name to the
canonical object (``` `<->` = list_distance ```) in `R/zzz-dd.R`; say the word and
I will add it.

## Generality

`no_implement` is a set, not a special case, so any future DuckDB name that
cannot be an R object can be documented the same way.

With this, **every edge-case function is resolved with no omissions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)